### PR TITLE
Add null provider for the privacy API

### DIFF
--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -2,7 +2,7 @@
 namespace block_equella_tasks\privacy;
 
 class provider implements \core_privacy\local\metadata\null_provider {
-    //this plugin does not store any personal user data.
+    // this plugin does not store any personal user data.
     /**
      * Get the language string identifier with the component's language
      * file to explain why this plugin stores no data.

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -1,0 +1,13 @@
+<?php
+namespace block_equella_tasks\privacy;
+
+class provider implements \core_privacy\local\metadata\null_provider {
+    //this plugin does not store any personal user data.
+    /**
+     * Get the language string identifier with the component's language
+     * file to explain why this plugin stores no data.
+     */
+    public static function get_reason(): string {
+        return 'privacy:metadata';
+    }
+}

--- a/lang/en/block_equella_tasks.php
+++ b/lang/en/block_equella_tasks.php
@@ -19,5 +19,4 @@ $string['pluginname'] = 'openEQUELLA Tasks';
 $string['incompatible'] = 'This version of openEQUELLA is incompatible with this block';
 $string['error'] = 'There has been an error connecting to openEQUELLA.  Will try again in 5 minutes.';
 $string['notasks'] = 'You currently have no tasks';
-
-?>
+$string['privacy:metadata'] = "The TASKS block does not store any data - it uses shared secret to interact with openEQUELLA.";

--- a/lang/en/block_equella_tasks.php
+++ b/lang/en/block_equella_tasks.php
@@ -19,4 +19,4 @@ $string['pluginname'] = 'openEQUELLA Tasks';
 $string['incompatible'] = 'This version of openEQUELLA is incompatible with this block';
 $string['error'] = 'There has been an error connecting to openEQUELLA.  Will try again in 5 minutes.';
 $string['notasks'] = 'You currently have no tasks';
-$string['privacy:metadata'] = "The TASKS block does not store any data - it uses shared secret to interact with openEQUELLA.";
+$string['privacy:metadata'] = "This block does not store any data - it uses a shared secret to interact with openEQUELLA";

--- a/lang/en/block_equella_tasks.php
+++ b/lang/en/block_equella_tasks.php
@@ -19,4 +19,4 @@ $string['pluginname'] = 'openEQUELLA Tasks';
 $string['incompatible'] = 'This version of openEQUELLA is incompatible with this block';
 $string['error'] = 'There has been an error connecting to openEQUELLA.  Will try again in 5 minutes.';
 $string['notasks'] = 'You currently have no tasks';
-$string['privacy:metadata'] = "This block does not store any data - it uses a shared secret to interact with openEQUELLA";
+$string['privacy:metadata'] = "This block does not store any data.";

--- a/version.php
+++ b/version.php
@@ -24,5 +24,6 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2011021501;
+$plugin->version = 2020032500;
 $plugin->component = 'block_equella_tasks'; // Full name of the plugin (used for diagnostics)
+$plugin->release = "1.0.0";


### PR DESCRIPTION
Moodle now adheres to the GDPR which means we need to implement a privacy provider. 
See https://docs.moodle.org/dev/Privacy_API#Plugins_which_do_not_store_personal_data for details.  

![image](https://user-images.githubusercontent.com/24543345/91247543-d7823700-e795-11ea-8da0-036e3d89578a.png)
